### PR TITLE
fix(wasmldr): use safe memory config defaults

### DIFF
--- a/internal/wasmldr/src/workload.rs
+++ b/internal/wasmldr/src/workload.rs
@@ -59,8 +59,13 @@ pub fn run<T: AsRef<str>, U: AsRef<str>>(
     config.wasm_module_linking(true);
     // module-linking requires multi-memory
     config.wasm_multi_memory(true);
+
     // Prefer dynamic memory allocation style over static memory
     config.static_memory_maximum_size(0);
+    config.static_memory_guard_size(0);
+    config.dynamic_memory_guard_size(0);
+    config.dynamic_memory_reserved_for_growth(1 * 1024 * 1024);
+
     let engine = wasmtime::Engine::new(&config).or(Err(Error::ConfigurationError))?;
 
     debug!("instantiating wasmtime linker");


### PR DESCRIPTION
SGX can't `mprotect`, so segfaults don't work, therefore disable guard
pages and fallback to full bounds checks.

Limit the default memory reserved for growth to 1MB, instead of the
default 2GB for 64bit architectures.

Signed-off-by: Harald Hoyer <harald@profian.com>