### PR TITLE
fix: Use `spinning` instead of `once_cell` with static only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,6 @@ dependencies = [
  "lset",
  "mmarinus",
  "nbytes",
- "once_cell",
  "openssl",
  "primordial",
  "process_control",
@@ -160,6 +159,7 @@ dependencies = [
  "semver",
  "serial_test",
  "sgx",
+ "spinning",
  "structopt",
  "tempdir",
  "vdso",
@@ -695,6 +695,15 @@ name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "spinning"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ libc = "0.2"
 lset = "0.2"
 vdso = "0.1"
 log = "0.4"
-once_cell = "1.8"
+spinning = "0.1.0"
 env_logger = "0.9"
 
 [build-dependencies]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -17,8 +17,7 @@ use std::sync::Arc;
 use anyhow::{Error, Result};
 use mmarinus::{perms, Map};
 use sallyport::Block;
-
-use once_cell::sync::OnceCell;
+use spinning::Lazy;
 
 trait Config: Sized {
     type Flags;
@@ -100,15 +99,11 @@ pub enum Command<'a> {
     Continue,
 }
 
-#[inline]
-pub fn builtin_backends() -> &'static [Box<dyn Backend>] {
-    static BACKENDS: OnceCell<Vec<Box<dyn Backend>>> = OnceCell::new();
-    &BACKENDS.get_or_init(|| {
-        vec![
-            #[cfg(feature = "backend-sgx")]
-            Box::new(sgx::Backend),
-            #[cfg(feature = "backend-kvm")]
-            Box::new(kvm::Backend),
-        ]
-    })[..]
-}
+pub static BACKENDS: Lazy<Vec<Box<dyn Backend>>> = Lazy::new(|| {
+    vec![
+        #[cfg(feature = "backend-sgx")]
+        Box::new(sgx::Backend),
+        #[cfg(feature = "backend-kvm")]
+        Box::new(kvm::Backend),
+    ]
+});

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::backend::builtin_backends;
+use crate::backend::BACKENDS;
 use crate::cli::{Result, StructOpt};
+use std::ops::Deref;
 
 /// Show details about backend support on this system
 #[derive(StructOpt, Debug)]
@@ -13,7 +14,7 @@ impl Options {
     pub fn display(self) -> Result<()> {
         use colorful::*;
 
-        for backend in builtin_backends() {
+        for backend in BACKENDS.deref() {
             println!("Backend: {}", backend.name());
 
             let data = backend.data();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ mod log;
 mod run;
 
 use anyhow::{anyhow, Result};
+use std::ops::Deref;
 use structopt::{clap::AppSettings, StructOpt};
 
 pub use self::log::LogOptions;
@@ -23,7 +24,7 @@ pub enum Command {
 // Options & shared setup code for backends/shims
 //
 
-use crate::backend::{builtin_backends, Backend};
+use crate::backend::{Backend, BACKENDS};
 
 #[derive(StructOpt, Debug)]
 pub struct BackendOptions {
@@ -36,15 +37,15 @@ pub struct BackendOptions {
 
 impl BackendOptions {
     pub fn pick(&self) -> Result<&dyn Backend> {
-        let backends = builtin_backends();
-
         if let Some(ref name) = self.backend {
-            backends
+            BACKENDS
+                .deref()
                 .iter()
                 .find(|b| b.have() && b.name() == name)
                 .ok_or_else(|| anyhow!("Keep backend {:?} is unsupported", name))
         } else {
-            backends
+            BACKENDS
+                .deref()
                 .iter()
                 .find(|b| b.have())
                 .ok_or_else(|| anyhow!("No supported backend found"))
@@ -56,7 +57,7 @@ impl BackendOptions {
 //
 // Options & shared setup code for workldr
 //
-use crate::workldr::{builtin_workldrs, Workldr};
+use crate::workldr::{Workldr, WORKLDRS};
 
 #[derive(StructOpt, Debug)]
 pub struct WorkldrOptions {
@@ -65,9 +66,8 @@ pub struct WorkldrOptions {
 
 impl WorkldrOptions {
     pub fn pick(&self) -> Result<&dyn Workldr> {
-        let workldrs = builtin_workldrs();
-
-        workldrs
+        WORKLDRS
+            .deref()
             .iter()
             .find(|_| true)
             .ok_or_else(|| anyhow!("No supported workldr found"))

--- a/src/workldr/mod.rs
+++ b/src/workldr/mod.rs
@@ -24,7 +24,7 @@
 #[cfg(feature = "wasmldr")]
 pub mod wasmldr;
 
-use once_cell::sync::OnceCell;
+use spinning::Lazy;
 
 /// A trait for the "Workloader" - shortened to Workldr, also known as "exec"
 /// (as in Backend::keep(shim, exec) [q.v.]) and formerly known as the "code"
@@ -40,13 +40,9 @@ pub trait Workldr: Sync + Send {
     fn exec(&self) -> &'static [u8];
 }
 
-#[inline]
-pub fn builtin_workldrs() -> &'static [Box<dyn Workldr>] {
-    static WORKLDRS: OnceCell<Vec<Box<dyn Workldr>>> = OnceCell::new();
-    &WORKLDRS.get_or_init(|| {
-        vec![
-            #[cfg(feature = "wasmldr")]
-            Box::new(wasmldr::Wasmldr),
-        ]
-    })[..]
-}
+pub static WORKLDRS: Lazy<Vec<Box<dyn Workldr>>> = Lazy::new(|| {
+    vec![
+        #[cfg(feature = "wasmldr")]
+        Box::new(wasmldr::Wasmldr),
+    ]
+});


### PR DESCRIPTION
The `shim-sev` is already using `spinning`, so we would safe one more
dependency.

Signed-off-by: Harald Hoyer <harald@profian.com>